### PR TITLE
HACK: Don't follow CNAME for Apex query unless A or AAAA

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -153,7 +153,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 	// Found entire name.
 	if found && shot {
 
-		if rrs := elem.Type(dns.TypeCNAME); len(rrs) > 0 && qtype != dns.TypeCNAME {
+		if rrs := elem.Type(dns.TypeCNAME); len(rrs) > 0 && qtype != dns.TypeCNAME && (qtype == dns.TypeA || qtype == dns.TypeAAAA || qname != z.origin) {
 			return z.externalLookup(ctx, state, elem, rrs)
 		}
 


### PR DESCRIPTION
Allows Alias plugin to function as expected with file plugin.
Stops file plugin from following CNAMEs on the zone apex - unless it's a A or AAAA query.